### PR TITLE
Fixing Scheduled Trains + Making Train Polls Optional

### DIFF
--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -13,9 +13,8 @@ from zoneinfo import ZoneInfo
 import discord
 from discord.ext import commands
 
-from iGritty.common.params import DEBUG_MSG_DURATION_SECONDS
-from iGritty.db import iGrittyDB
 from iGritty.common.utils import SupportedTrainRecurrance
+from iGritty.db import iGrittyDB
 
 DEFAULT_LEAD_TIME_MINS: int = 10
 TIMEZONE: ZoneInfo = ZoneInfo("America/New_York")
@@ -235,7 +234,7 @@ class GameTrainScheduler(commands.Cog):
         delay = (run_time - now).total_seconds()
         if delay < 0:
             msg = f"Cannot schedule train for the past ({run_time.strftime('%Y-%m-%d %H:%M:%S')})"
-            await ctx.send(msg, delete_after=DEBUG_MSG_DURATION_SECONDS)
+            await ctx.send(msg)
             logger.error(msg)
 
         # Get the channel
@@ -246,7 +245,7 @@ class GameTrainScheduler(commands.Cog):
 
         if channel is None:
             msg = "Unable to determine channel to run train"
-            await ctx.send(msg, delete_after=DEBUG_MSG_DURATION_SECONDS)
+            await ctx.send(msg)
             logger.error(msg)
 
         task = asyncio.create_task(self.run_train_at_time(game=game, start_time=run_time, channel_id=channel.id))
@@ -300,7 +299,7 @@ class GameTrainScheduler(commands.Cog):
                     f"* Train #{train_id} in {channel_name} departing at {departure_datetime}"
                     f"{f' for {game}' if game else ''}"
                 )
-            await ctx.channel.send("\n".join(msg), delete_after=DEBUG_MSG_DURATION_SECONDS)
+            await ctx.channel.send("\n".join(msg))
         else:
             await ctx.channel.send("No upcoming trains!")
 
@@ -323,10 +322,7 @@ class GameTrainScheduler(commands.Cog):
                 f"Removed train #{train_id} from the schedule",
             )
         else:
-            await ctx.channel.send(
-                f"No train with id {train_id} found",
-                delete_after=DEBUG_MSG_DURATION_SECONDS,
-            )
+            await ctx.channel.send(f"No train with id {train_id} found")
 
     @commands.command(name="train")
     async def launch_train_now(

--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -141,13 +141,18 @@ class GameTrainScheduler(commands.Cog):
 
         departure_time = (datetime.datetime.now(tz=TIMEZONE) + lead_time).strftime("%I:%M %p")
 
+        # Start with custom message, if provided
         if custom_message:
             msg = custom_message
         else:
-            msg = f"Game Train departing in {lead_time.seconds // 60} minutes! (At {departure_time} EST)"
+            msg = f"Game Train departing in {lead_time.seconds // 60} minutes!"
 
+        # Append game name time prefix, if provided
         if game_name:
             msg = f"[{game_name}] {msg}"
+
+        # Append departure time suffix
+        msg = f"{msg} (At {departure_time} EST)"
 
         if add_poll:
             train_poll = discord.Poll(

--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -89,7 +89,7 @@ class GameTrainScheduler(commands.Cog):
         now = datetime.datetime.now()
 
         for train in self.db.get_trains():
-            train_id, game, channel_name, departure_datetime, recurrance = train
+            train_id, game, custom_message, add_poll, departure_datetime, channel_name, recurrance = train
 
             # If this train is expired ...
             if departure_datetime < now:
@@ -128,7 +128,13 @@ class GameTrainScheduler(commands.Cog):
             channel_id = self.db.get_id_for_channel("text", channel_name=channel_name)
 
             task = asyncio.create_task(
-                self.run_train_at_time(game=game, start_time=departure_datetime, channel_id=channel_id)
+                self.run_train_at_time(
+                    game=game,
+                    custom_message=custom_message,
+                    add_poll=add_poll,
+                    start_time=departure_datetime,
+                    channel_id=channel_id,
+                )
             )
             self._scheduled_train_tasks[train_id] = task
 

--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -355,7 +355,7 @@ class GameTrainScheduler(commands.Cog):
         if upcoming_trains := self.db.get_trains(channel_name=channel.name if channel else None):
             msg = [f"The next [{len(upcoming_trains)}] train(s) are: "]
             for train in upcoming_trains:
-                train_id, game, channel_name, departure_datetime, _ = train
+                train_id, game, _, _, departure_datetime, channel_name, _ = train
                 msg.append(
                     f"* Train #{train_id} in {channel_name} departing at {departure_datetime}"
                     f"{f' for {game}' if game else ''}"

--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -205,7 +205,6 @@ class GameTrainScheduler(commands.Cog):
         Schedule a game train for departure at a specific time
 
         Arguments:
-            ctx (commands.Context): context in which this command is called
             time_str (str): The time to run the train, HH:MM format, must still be today
             game (str, optional): game for which to schedule the train
             recurrance (str, optional): game for which to schedule the train
@@ -280,7 +279,6 @@ class GameTrainScheduler(commands.Cog):
         List the upcoming trains
 
         Arguments:
-            ctx (commands.Context): context in which this command is called
             channel_id (int, optional): the channel for which to check for trains
 
         """
@@ -309,7 +307,6 @@ class GameTrainScheduler(commands.Cog):
         Cancel the given train
 
         Arguments:
-            ctx (commands.Context): context in which this command is called
             train_id (int): the train which should be cancelled
 
         """
@@ -336,10 +333,9 @@ class GameTrainScheduler(commands.Cog):
         Launch the game train now in this channel
 
         Arguments:
-            ctx (commands.Context): context in which this command is called
-            game (str, optional): game for which to the train should run
+            game (str, optional): game for which the train should run
             custom_message (str, optional): overwrite the game train message with a given message
-            add_poll (book, optional): whether to add a poll to this train
+            add_poll (bool, optional): whether to add a poll to this train
 
         """
         logger.info("Launching user-requested game train for game %s", game)

--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -104,7 +104,7 @@ class GameTrainScheduler(commands.Cog):
 
                     # And adjust to tomorrow if we've missed the runtime for today
                     if next_runtime < now:
-                        next_runtime.replace(day=now.day + 1)
+                        next_runtime = next_runtime.replace(day=now.day + 1)
                         logger.info(
                             "Updating daily scheduled train to run tomorrow [%s] (%s)",
                             train,

--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -337,7 +337,9 @@ class GameTrainScheduler(commands.Cog):
 
         Arguments:
             ctx (commands.Context): context in which this command is called
-            game (str, optional): game for which to run the train
+            game (str, optional): game for which to the train should run
+            custom_message (str, optional): overwrite the game train message with a given message
+            add_poll (book, optional): whether to add a poll to this train
 
         """
         logger.info("Launching user-requested game train for game %s", game)

--- a/src/iGritty/cogs/game_train_scheduler.py
+++ b/src/iGritty/cogs/game_train_scheduler.py
@@ -210,7 +210,7 @@ class GameTrainScheduler(commands.Cog):
         Schedule a game train for departure at a specific time
 
         Arguments:
-            time_str (str): The time to run the train, HH:MM format, must still be today
+            time_str (str): The time to run the train, HH:MM format
             game (str, optional): game for which to schedule the train
             recurrance (str, optional): game for which to schedule the train
             date_str (str, optional): The date to run the train, DD/MM/YYYY format, must be in the future.
@@ -237,9 +237,18 @@ class GameTrainScheduler(commands.Cog):
         now = datetime.datetime.now()
         delay = (run_time - now).total_seconds()
         if delay < 0:
-            msg = f"Cannot schedule train for the past ({run_time.strftime('%Y-%m-%d %H:%M:%S')})"
-            await ctx.send(msg)
-            logger.error(msg)
+            if recurrance == SupportedTrainRecurrance.ONCE:
+                msg = f"Cannot schedule one-time train for the past ({run_time.strftime('%Y-%m-%d %H:%M:%S')})"
+                await ctx.send(msg)
+                logger.error(msg)
+            elif recurrance == SupportedTrainRecurrance.DAILY:
+                await ctx.send(f"Train with {recurrance.lower()} recurrance will run for the first time tomorrow.")
+                run_time.day = run_time.day + 1
+            elif recurrance == SupportedTrainRecurrance.WEEKLY:
+                await ctx.send(f"Train with {recurrance.lower()} recurrance will run for the first time next week.")
+                run_time.day = run_time.day + 7
+            else:
+                raise NotImplementedError(f"No defined schedule behavior for {recurrance} recurrance")
 
         # Get the channel
         if channel_id is not None:

--- a/src/iGritty/common/utils.py
+++ b/src/iGritty/common/utils.py
@@ -26,6 +26,9 @@ class StrEnum(str, Enum):
                     return member
         super()._missing_(value)
 
+    def __str__(self):
+        return self.value
+
 
 class SupportedChannelType(StrEnum):
     """Channel types supported for DB operations"""

--- a/src/iGritty/main.py
+++ b/src/iGritty/main.py
@@ -16,7 +16,6 @@ from dotenv import load_dotenv
 
 from iGritty import __version__ as bot_version
 from iGritty.cogs.game_train_scheduler import GameTrainScheduler
-from iGritty.common.params import DEBUG_MSG_DURATION_SECONDS
 from iGritty.db import iGrittyDB
 
 # -------------
@@ -74,14 +73,11 @@ async def on_ready():
 @bot.command()
 async def version(ctx: commands.Context):
     """
-    Retrieve the bot version (message is removed after 10 seconds)
+    Retrieve the bot version
 
     """
     logger.info("Version requested [%s]", bot_version)
-    await ctx.send(
-        f"iGritty Discord Bot version {bot_version}",
-        delete_after=DEBUG_MSG_DURATION_SECONDS,
-    )
+    await ctx.send(f"iGritty Discord Bot version {bot_version}")
 
 
 def run():

--- a/src/iGritty/main.py
+++ b/src/iGritty/main.py
@@ -43,13 +43,16 @@ logger.addHandler(handler)
 load_dotenv()
 API_KEY = os.getenv("BOT_TOKEN")
 DESCRIPTION = "Gritty is trapped in a Discord Bot!"
+help_command = commands.DefaultHelpCommand(show_parameter_descriptions=False)
 
 intents = discord.Intents.default()
 intents.members = True
 intents.message_content = True
 
+
 bot = commands.Bot(
     command_prefix="!",
+    help_command=help_command,
     description=DESCRIPTION,
     intents=intents,
 )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -54,70 +54,83 @@ class TestiGrittyDB:
         assert (
             example_db.add_train_to_table(
                 "Bad Rats",
-                "cool_channel",
+                None,
+                False,
                 in_an_hour,
+                "cool_channel",
             )
             == 1
         )
 
         assert example_db.get_trains() == [
-            (1, "Bad Rats", "cool_channel", in_an_hour, "ONCE"),
+            (1, "Bad Rats", None, False, in_an_hour, "cool_channel", "ONCE"),
         ]
 
         assert (
             example_db.add_train_to_table(
                 "Half Life 3",
-                "other_channel",
+                "Poggo",
+                False,
                 tomorrow,
+                "other_channel",
                 "DAILY",
             )
             == 2
         )
 
         assert example_db.get_trains() == [
-            (1, "Bad Rats", "cool_channel", in_an_hour, "ONCE"),
-            (2, "Half Life 3", "other_channel", tomorrow, "DAILY"),
+            (1, "Bad Rats", None, False, in_an_hour, "cool_channel", "ONCE"),
+            (2, "Half Life 3", "Poggo", False, tomorrow, "other_channel", "DAILY"),
         ]
 
         assert (
             example_db.add_train_to_table(
                 "Dota 1",
-                "no channel",
+                None,
+                True,
                 yesterday,
+                "no channel",
                 "WEEKLY",
             )
             == 3
         )
 
         assert example_db.get_trains() == [
-            (3, "Dota 1", "no channel", yesterday, "WEEKLY"),
-            (1, "Bad Rats", "cool_channel", in_an_hour, "ONCE"),
-            (2, "Half Life 3", "other_channel", tomorrow, "DAILY"),
+            (3, "Dota 1", None, True, yesterday, "no channel", "WEEKLY"),
+            (1, "Bad Rats", None, False, in_an_hour, "cool_channel", "ONCE"),
+            (2, "Half Life 3", "Poggo", False, tomorrow, "other_channel", "DAILY"),
         ]
 
         # Then, try removing 2 items from the DB
         example_db.remove_train(1)
 
         assert example_db.get_trains() == [
-            (3, "Dota 1", "no channel", yesterday, "WEEKLY"),
-            (2, "Half Life 3", "other_channel", tomorrow, "DAILY"),
+            (3, "Dota 1", None, True, yesterday, "no channel", "WEEKLY"),
+            (2, "Half Life 3", "Poggo", False, tomorrow, "other_channel", "DAILY"),
         ]
 
         example_db.remove_train(3)
 
         assert example_db.get_trains() == [
-            (2, "Half Life 3", "other_channel", tomorrow, "DAILY"),
+            (2, "Half Life 3", "Poggo", False, tomorrow, "other_channel", "DAILY"),
         ]
 
         # Finally, try removing adding back 1 item to the DB
         assert (
-            example_db.add_train_to_table("Hairspray", "pool_channel", tomorrow, "ONCE")
+            example_db.add_train_to_table(
+                "Hairspray",
+                "The musical",
+                True,
+                tomorrow,
+                "pool_channel",
+                "ONCE",
+            )
             == 4
         )
 
         assert example_db.get_trains() == [
-            (2, "Half Life 3", "other_channel", tomorrow, "DAILY"),
-            (4, "Hairspray", "pool_channel", tomorrow, "ONCE"),
+            (2, "Half Life 3", "Poggo", False, tomorrow, "other_channel", "DAILY"),
+            (4, "Hairspray", "The musical", True, tomorrow, "pool_channel", "ONCE"),
         ]
 
         # Invalid input testing


### PR DESCRIPTION
This changeset includes...
* A Fix for https://github.com/dfierros/iGritty/issues/3
* Polls are now an optional part of trains, with the default behavior being to _not_ include a poll

Turns out the train reload from the database was always throwing out any train that has run once, including those with recurrence. Fixed this for daily trains, but weekly trains are still a little bit weird and may not behave as expected.